### PR TITLE
#223 - Improve before-index performance

### DIFF
--- a/scripts/benchmarks.clj
+++ b/scripts/benchmarks.clj
@@ -335,3 +335,20 @@
     (transform (walker number?) inc data)
     (transform (walker-old number?) inc data)
     ))
+
+(let [size 1000
+      middle-idx (/ size 2)
+      v -1
+      rng (range size)
+      data-vec (vec rng)
+      data-lst (apply list rng)]
+  (run-benchmark "before-index vs. srange in middle (vector)"
+    (setval (before-index middle-idx) v data-vec)
+    (setval (srange middle-idx middle-idx) [v] data-vec))
+  (run-benchmark "before-index vs. srange in middle (list)"
+    (setval (before-index middle-idx) v data-lst)
+    (setval (srange middle-idx middle-idx) [v] data-lst))
+  (run-benchmark "before-index at 0 vs. srange vs. cons (list)"
+    (setval (before-index 0) v data-lst)
+    (setval (srange 0 0) [v] data-lst)
+    (cons v data-lst)))

--- a/src/clj/com/rpl/specter.cljc
+++ b/src/clj/com/rpl/specter.cljc
@@ -974,11 +974,10 @@
     NONE)
   (transform* [this vals structure next-fn]
     (let [v (next-fn vals NONE)]
-      (if (identical? NONE v)
-        structure
-        ;; TODO: make a more efficient impl
-        (setval (srange index index) [v] structure)
-        ))))
+      (if
+        (identical? NONE v)
+          structure
+          (n/insert-before-idx structure index v)))))
 
 (defrichnav
   ^{:doc "Navigates to the index of the sequence if within 0 and size. Transforms move element

--- a/test/com/rpl/specter/core_test.cljc
+++ b/test/com/rpl/specter/core_test.cljc
@@ -1609,14 +1609,18 @@
 
 (deftest before-index-test
   (let [data [1 2 3]
-        datal '(1 2 3)]
+        datal '(1 2 3)
+        data-str "abcdef"]
     (is (predand= vector? [:a 1 2 3] (setval (s/before-index 0) :a data)))
     (is (predand= vector? [1 2 3] (setval (s/before-index 1) s/NONE data)))
     (is (predand= vector? [1 :a 2 3] (setval (s/before-index 1) :a data)))
     (is (predand= vector? [1 2 3 :a] (setval (s/before-index 3) :a data)))
+    ; ensure inserting at index 0 in nil structure works, as in previous impl
+    (is (predand= vector? '[:a] (setval (s/before-index 0) :a nil)))
     (is (predand= list? '(:a 1 2 3) (setval (s/before-index 0) :a datal)))
     (is (predand= list? '(1 :a 2 3) (setval (s/before-index 1) :a datal)))
     (is (predand= list? '(1 2 3 :a) (setval (s/before-index 3) :a datal)))
+    (is (predand= string? "abcxdef" (setval (s/before-index 3) (char \x) data-str)))
     ))
 
 (deftest index-nav-test


### PR DESCRIPTION
Adding before-index implementation that uses take/drop instead of setval/srange

Adding new functional test to confirm behavior when operating on a string

Adding benchmark for old versus new implementation of before-index

(Work in progress; the `before-index` implementation would be swapped out in the final patch).

Sample benchmark output:

    ********************************                                                                                                                                                                                                 
    [47/1113]
    
    Benchmark: old versus new before-index implementation
    
    Mean(us)        vs best         Code
    0.0838           1.00            (setval (before-index-new insert-idx) -1 data)
    136              1.62e+03                (setval (before-index-old insert-idx) -1 data)

