### PR TITLE
Add Navigators for Sorted Sequences

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## 1.1.4-SNAPSHOT
 
+* Add SORTED, sorted, and sorted-by navs (thanks @IGJoshua)
 * Add arglist metadata to navs (thanks @phronmophobic)
 * Improve before-index performance by 150x on lists and 5x on vectors (thanks @jeff303)
 * Bug fix: BEFORE-ELEM, AFTER-ELEM, FIRST, LAST, BEGINNING, and END on subvecs now produce vector type in cljs

--- a/src/clj/com/rpl/specter.cljc
+++ b/src/clj/com/rpl/specter.cljc
@@ -1504,3 +1504,61 @@
    [& path]
    (map compact* path)
    ))
+
+(defnav
+  ^{:doc "Navigates to a sequence resulting from (sort ...), but is a
+         view to the original structure that can be transformed.
+
+         If the transformed sequence is smaller than the input sequence, values
+         which are included are sorted by the same indices as the input value's
+         index in the input sequence.
+
+         If the transformed sequence is larger than the input sequence, values
+         added to the end of the sequence will be appended to the end of the
+         original sequence."}
+  SORTED
+  []
+  (select* [this structure next-fn]
+    (n/sorted-select structure identity compare next-fn))
+  (transform* [this structure next-fn]
+    (n/sorted-transform structure identity compare next-fn)))
+
+(defnav
+  ^{:doc "Navigates to a sequence resulting from (sort comparator ...), but
+         is a view to the original structure that can be transformed.
+
+         If the transformed sequence is smaller than the input sequence, values
+         which are included are sorted by the same indices as the input value's
+         index in the input sequence.
+
+         If the transformed sequence is larger than the input sequence, values
+         added to the end of the sequence will be appended to the end of the
+         original sequence."}
+  sorted
+  [comparator]
+  (select* [this structure next-fn]
+    (n/sorted-select structure identity comparator next-fn))
+  (transform* [this structure next-fn]
+    (n/sorted-transform structure identity comparator next-fn)))
+
+(defdynamicnav sorted-by
+  "Navigates to a sequence sorted by the value stored in the keypath, by the
+  comparator, if one is provided.
+
+  This sequence is a view to the original structure that can be transformed. If
+  the transformed sequence is smaller than the input sequence, values which are
+  included are sorted by the same indices as the input value's index in the
+  input sequence.
+
+  If the transformed sequence is larger than the input sequence, values added to
+  the end of the sequence will be appended to the end of the original sequence.
+
+  Value collection (e.g. collect, collect-one) may not be used in the keypath."
+  ([keypath] (sorted-by keypath compare))
+  ([keypath comparator]
+   (late-bound-nav [late (late-path keypath)
+                    late-fn comparator]
+     (select* [this structure next-fn]
+       (n/sorted-select structure #(compiled-select late %) late-fn next-fn))
+     (transform* [this structure next-fn]
+       (n/sorted-transform structure #(compiled-select late %) late-fn next-fn)))))

--- a/src/clj/com/rpl/specter/impl.cljc
+++ b/src/clj/com/rpl/specter/impl.cljc
@@ -546,6 +546,16 @@
         res
         ))))
 
+(defn sorted-transform*
+  [structure keyfn comparator next-fn]
+  (let [sorted (sort-by (comp keyfn second) comparator (map-indexed vector structure))
+        indices (map first sorted)
+        result (next-fn (map second sorted))
+        unsorted (sort-by first compare (map vector (concat indices (repeat ##Inf)) result))]
+    (into (empty structure)
+          (map second)
+          unsorted)))
+
 (defn- matching-indices [aseq p]
   (keep-indexed (fn [i e] (if (p e) i)) aseq))
 

--- a/src/clj/com/rpl/specter/navs.cljc
+++ b/src/clj/com/rpl/specter/navs.cljc
@@ -381,6 +381,11 @@
 
 (def srange-transform i/srange-transform*)
 
+(defn sorted-select
+  [structure keyfn comparator next-fn]
+  (next-fn (sort-by keyfn comparator structure)))
+
+(def sorted-transform i/sorted-transform*)
 
 (defn extract-basic-filter-fn [path]
   (cond (fn? path)


### PR DESCRIPTION
This PR adds support for three new navigators which all navigate to a sorted version of the current sequence.

- `SORTED`, a parameter-less navigator which navigates to a transformable view of the current sequence as if it were run through `sort`
- `sorted`, a single-parameter navigator which is the same as `SORTED` but takes a comparator
- `sorted-by`, a dynamic navigator which takes a keypath for the sort key and an optional comparator

Before this PR can be merged, the following steps must be completed by the author:
- [ ] Add tests

This PR implements what was discussed in #316.