### PR TITLE
feat: export commonly-used clj-kondo config

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,1 @@
+{:config-paths ["../resources/clj-kondo.exports/com/rpl/specter"]}

--- a/README.md
+++ b/README.md
@@ -334,6 +334,21 @@ When using Specter in a project with [clj-kondo](https://github.com/clj-kondo/cl
            com.rpl.specter/defrichnav clojure.core/defn}}
 ```
 
+The config is included in the repo and can be [imported as indicated in
+the clj-kondo
+documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/config.md#importing):
+
+```sh
+clj-kondo --lint "$(clojure -Spath)" --copy-configs --skip-lint
+```
+
+or, if using lein,
+
+```sh
+clj-kondo --lint "$(lein classpath)" --copy-configs --skip-lint
+```
+
+
 # Babashka
 
 This library is compatible with [babashka](https://babashka.org/) as of specter 1.1.4 and babashka 0.7.8.

--- a/resources/clj-kondo.exports/com/rpl/specter/config.edn
+++ b/resources/clj-kondo.exports/com/rpl/specter/config.edn
@@ -1,0 +1,6 @@
+{:lint-as {com.rpl.specter/defcollector clojure.core/defn
+           com.rpl.specter/defdynamicnav clojure.core/defn
+           com.rpl.specter/defmacroalias clojure.core/def
+           com.rpl.specter/defnav clojure.core/defn
+           com.rpl.specter/defrichnav clojure.core/defn}
+ :hooks {:analyze-call {com.rpl.specter/recursive-path hooks.specter/recursive-path}}}

--- a/resources/clj-kondo.exports/com/rpl/specter/hooks/specter.clj_kondo
+++ b/resources/clj-kondo.exports/com/rpl/specter/hooks/specter.clj_kondo
@@ -1,0 +1,12 @@
+(ns hooks.specter
+  (:require [clj-kondo.hooks-api :as api]))
+
+;; (sp/recursive-path [x y] p ...) ≈ (fn [x y p] ...)
+(defn recursive-path [{:keys [:node]}]
+  (let [[args self-sym & body] (rest (:children node))
+        new-args (update args :children #(conj % self-sym))
+        new-node (api/list-node
+                  (list* (api/token-node 'fn)
+                         new-args
+                         body))]
+    {:node new-node}))


### PR DESCRIPTION
Hi, I found [a thread in clojurians between @borkdude and @IGJoshua](https://clojurians.slack.com/archives/CHY97NXE2/p1622152866095800) about adding an exported clj-kondo config with the common linters [added to the README](https://github.com/redplanetlabs/specter/pull/311). I can't find any discussion that follow to see if there was an attempt to add it and it was rejected for some reason though so I'm opening this in case it hasn't been done and there's interest. We use this with a hook for `recursive-path` - I'm not sure where that came from so I'm not taking credit for it or any of this 😀. 

I've also modified the README to document the exported config.